### PR TITLE
GWT690 - Change About Geomajas url from SVN to Github

### DIFF
--- a/client/src/main/java/org/geomajas/gwt/client/action/menu/AboutAction.java
+++ b/client/src/main/java/org/geomajas/gwt/client/action/menu/AboutAction.java
@@ -53,8 +53,7 @@ public class AboutAction extends MenuAction {
 		HTMLFlow flow = new HTMLFlow("<h2>Geomajas " + Geomajas.getVersion() + "</h2>" + "<p>"
 				+ MESSAGES.aboutCopyRight() + "</p>" + "<p>" + MESSAGES.aboutVisit()
 				+ ": <a href='http://www.geomajas.org/'>http://www.geomajas.org/</a><br />"
-				+ MESSAGES.sourceUrl() + ": <a href='http://ci.geomajas.org/svn/'>http://ci.geomajas.org/svn/</a> "
-				+ "&amp; <a href='https://svn.geomajas.org/majas/'>https://svn.geomajas.org/majas/</a> </p>");
+				+ MESSAGES.sourceUrl() + ": <a href='https://github.com/geomajas/geomajas-project-client-gwt'>https://github.com/geomajas/geomajas-project-client-gwt</a> </p>");
 		layout.addMember(flow);
 
 		final HTMLFlow copyrightWidget = new HTMLFlow("Copyright info");


### PR DESCRIPTION
About Geomajas still show old Subversion url. Now changed to Github.
