### PR TITLE
GWT-706: remove collapse-all-properties for IE11 featureclicked

### DIFF
--- a/example/src/main/java/org/geomajas/gwt/example/GwtFaceExampleStandalone.gwt.xml
+++ b/example/src/main/java/org/geomajas/gwt/example/GwtFaceExampleStandalone.gwt.xml
@@ -31,7 +31,8 @@
 	<set-property name="locale" value="default" />
 	-->
 	<!-- Compile to a single file, this speeds up compilation at the penalty of creating a single large file -->
-	<collapse-all-properties />
+	<!-- Never use in production! IE11 problems -->
+	<!--<collapse-all-properties />-->
 
 	<entry-point class="org.geomajas.gwt.example.client.GwtFaceExampleStandalone"/>
 </module>


### PR DESCRIPTION
compare IE11: featureclicked and others
http://dev.geomajas.org/geomajas-gwt-face-example-1.16.0-SNAPSHOT/
http://dev.geomajas.org/geomajas-gwt-face-example-GWT-706_featureClicked/