### PR TITLE
GWT-721: advanced views images: correct url: remove starting slash

### DIFF
--- a/plugin/widget-advancedviews/advancedviews-gwt-example/src/main/webapp/WEB-INF/mapMain.xml
+++ b/plugin/widget-advancedviews/advancedviews-gwt-example/src/main/webapp/WEB-INF/mapMain.xml
@@ -159,7 +159,7 @@ http://www.springframework.org/schema/tx http://www.springframework.org/schema/t
 						<property name="themeConfigs">
 							<list>
 								<bean class="org.geomajas.widget.advancedviews.configuration.client.themes.ViewConfig">
-									<property name="icon" value="/images/Google_theme.png" />
+									<property name="icon" value="images/Google_theme.png" />
 									<property name="title" value="Google maps" />
 									<property name="description" value="Google maps" />
 									<property name="rangeConfigs">
@@ -167,7 +167,7 @@ http://www.springframework.org/schema/tx http://www.springframework.org/schema/t
 											<bean class="org.geomajas.widget.advancedviews.configuration.client.themes.RangeConfig">
 												<property name="minimumScale" value="1:5000" />
 												<property name="maximumScale" value="1:1" />
-												<property name="icon" value="/images/Google_theme.png" />
+												<property name="icon" value="images/Google_theme.png" />
 												<property name="layerConfigs">
 													<list>
 														<bean class="org.geomajas.widget.advancedviews.configuration.client.themes.LayerConfig">
@@ -193,7 +193,7 @@ http://www.springframework.org/schema/tx http://www.springframework.org/schema/t
 								</bean>
 
 								<bean class="org.geomajas.widget.advancedviews.configuration.client.themes.ViewConfig">
-									<property name="icon" value="/images/OSM_theme.png" />
+									<property name="icon" value="images/OSM_theme.png" />
 									<property name="title" value="OSM and WMS" />
 									<property name="description" value="OSM and WMS" />
 									<property name="rangeConfigs">
@@ -201,7 +201,7 @@ http://www.springframework.org/schema/tx http://www.springframework.org/schema/t
 											<bean class="org.geomajas.widget.advancedviews.configuration.client.themes.RangeConfig">
 												<property name="minimumScale" value="1:1000000000" />
 												<property name="maximumScale" value="1:1" />
-												<property name="icon" value="/images/OSM_theme.png" />
+												<property name="icon" value="images/OSM_theme.png" />
 												<property name="layerConfigs">
 													<list>
 														<bean class="org.geomajas.widget.advancedviews.configuration.client.themes.LayerConfig">


### PR DESCRIPTION
Images of themes buttons were not visible.

example at http://dev.geomajas.org/geomajas-widget-advancedviews-gwt-example-GWT-721_imagesAdvancedViews/